### PR TITLE
Tighten default security config for kube-state-metrics containers

### DIFF
--- a/charts/kube-state-metrics/values.yaml
+++ b/charts/kube-state-metrics/values.yaml
@@ -111,7 +111,12 @@ kubeRBACProxy:
   ## Specify security settings for a Container
   ## Allows overrides and additional options compared to (Pod) securityContext
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-  containerSecurityContext: {}
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -248,6 +253,7 @@ securityContext:
 ## Allows overrides and additional options compared to (Pod) securityContext
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 containerSecurityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   capabilities:
     drop:


### PR DESCRIPTION
- improve default containerSecurityContext for main container by adding `readOnlyRootFilesystem: true`
- copy-paste containerSecurityContext from main to rbac sidecar for better security out of the box